### PR TITLE
No need to require 'pages', 'static', etc. directories when creating skeleton

### DIFF
--- a/cactus.py
+++ b/cactus.py
@@ -551,10 +551,12 @@ def main(argv=sys.argv):
 	
 	path = os.path.abspath(sys.argv[1])
 	
+	# Verify we are working in cactus project unless we are starting
 	for p in ['pages', 'static', 'templates']:
-		if not os.path.isdir(os.path.join(path, p)):
-			print 'This does not look like a cactus project (missing "%s" subfolder)' % p
-			sys.exit()
+		if argv[2] != 'create':
+			if not os.path.isdir(os.path.join(path, p)):
+				print 'This does not look like a cactus project (missing "%s" subfolder)' % p
+				sys.exit()
 	
 	getattr(Site(path), argv[2])()
 


### PR DESCRIPTION
It seems like the restrictions on these directories should be relaxed when using 'create' since one of its' main goals is to setup these very directories.

Hopefully I'm not missing something.  I really like the project though!  Hope to deploy with it soon.
