### PR TITLE
Add support for Django custom template tags

### DIFF
--- a/cactus.py
+++ b/cactus.py
@@ -218,16 +218,19 @@ class Site(object):
 	
 	def loadExtras(self, force=False):
 		
-		sys.path.append(self.paths['extras'])
+		# sys.path.append(self.paths['extras'])
 		
 		if force:
 			for m in ['render', 'templatetags', 'hooks']:
 				if m in sys.modules:
 					del sys.modules[m]
 		
-		import render
-		import templatetags
-		import hooks
+		from extras import render
+		from extras import templatetags
+		from extras import hooks
+		
+		from django.template.loader import add_to_builtins
+		add_to_builtins('extras.templatetags')
 	
 		global render, templatetags, hooks
 	
@@ -276,6 +279,7 @@ class Site(object):
 		open(os.path.join(self.path, 'extras', 'render.py'), 'w').write(renderFile)
 		open(os.path.join(self.path, 'extras', 'hooks.py'), 'w').write(hooksFile)
 		open(os.path.join(self.path, 'extras', 'templatetags.py'), 'w').write("")
+		open(os.path.join(self.path, 'extras', '__init__.py'), 'w').write("")
 	
 		self.log('New project generated at %s' % self.path)
 


### PR DESCRIPTION
I am not sure if this is the best way. I have tried the following:
1. Original: I could not load the template tags.
2. Try `add_to_builtins('templatetags')`. This should works fine, however Django tried to split the submodule from the string so it failed with cannot split error message.
3. Try using sub classes in `templatetags.py`; It also fail and Django think it is not a valid module.

My test template tags is here: https://gist.github.com/1186583

Changes:
- Turn extras folder into a module, because `add_to_builtins` requires
  a _real module_ (`module[dot]submodule`)
- Changes:
  - Site.create: create `extras/__init__.py`
  - Site.loadExtras: load template tags with `add_to_builtins`
