### PR TITLE
Added an RSS feed for blogs

### DIFF
--- a/skeleton/pages/rss_2.0.xml
+++ b/skeleton/pages/rss_2.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<rss version="2.0">
+    <channel>
+    <title></title>
+    <link></link>
+    <description></description>
+    <language></language>
+    <image>
+      <title></title>
+      <url></url>
+      <link></link>
+    </image>
+    {% for post in posts %}
+    <item>
+      <title>{{ post.title }}</title>
+      <link>{{ post.path }}</link>
+      <description>{{ post.body }}</description>
+      <pubDate>{{ post.date|date:"c" }}</pubDate>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/skeleton/templates/base.html
+++ b/skeleton/templates/base.html
@@ -5,7 +5,8 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="viewport" content="width=device-width">
 
-	<link rel="shortcut icon" href="{{ STATIC_URL }}/favicon.ico"> 
+    <link href="{{ ROOT_URL }}/rss_2.0.xml" rel="alternate" type="application/rss+xml" />
+	<link rel="shortcut icon" href="{{ STATIC_URL }}/favicon.ico">
 	<link rel="stylesheet" href="{{ STATIC_URL }}/css/style.css">
 
 	{% block header %}


### PR DESCRIPTION
really simple rss feed; user will need to customize.

since i assume a lot of people are cname-ing their AWS sites, i left all the site data blank -- not sure how users can handle that.

ideally i guess it could be read from the config and creating a new site could ask a bunch of new optional questions.

do you have any design goals in mind for this stuff?  do you want this a pull request into your blog example?
