### PR TITLE
add plugin to support sass indent-language (different from scss format)

### DIFF
--- a/skeleton/plugins/sass.disabled.py
+++ b/skeleton/plugins/sass.disabled.py
@@ -1,0 +1,8 @@
+import os
+import pipes
+
+def postBuild(site):
+    os.system(
+        'sass -t compressed --update %s/static/css/*.sass' % 
+            pipes.quote(site.paths['build']
+    ))


### PR DESCRIPTION
This adds a 'sass.disabled.py' to the skeleton/plugins directory to support compiling static/css/*.sass files to their corresponding .css files.

sass is different from scss in that it doesn't use brackets and is whitespace-sensitive.

http://sass-lang.com/
