### PR TITLE
adding support for the google closure minifier

### DIFF
--- a/skeleton/plugins/google_closure_compiler.disabled.py
+++ b/skeleton/plugins/google_closure_compiler.disabled.py
@@ -2,27 +2,14 @@
 # would be better if the scripts were concatenated first, but that would involve
 # another plugin and then would have to allow either explicit or implicit ordering
 # of the files and then you'd have to setup an ordering of plugins to run...
-import httplib
-import urllib
-import sys
+import subprocess
 from glob import glob
 
 def postBuild(site):
     for script in glob('%s/static/js/*js' % site.paths['build']):
-        options = urllib.urlencode([
-            ('js_code', script),
-            ('compilation_level', 'SIMPLE_OPTIMIZATIONS'),
-            ('output_format', 'text'),
-            ('output_info', 'compiled_code'),])
-
         root_name = script.rsplit(',', 1)[0]
         dest = "%s.min.js" % root_name
-
-        headers = { "Content-type": "application/x-www-form-urlencoded" }
-        conn = httplib.HTTPConnection('closure-compiler.appspot.com')
-        conn.request('POST', '/compile', options, headers)
-        response = conn.getresponse()
-        data = response.read()
-        with open(dest, 'w') as fh:
-            fh.write(data);
-        conn.close
+        try:
+            subprocess.check_call(['java', '-jar', '/usr/local/lib/closure.jar', '--js', script, '--js_output_file', dest])
+        except subprocess.CalledProcessError:
+            print 'JS Compile step failed.'


### PR DESCRIPTION
i put this in the comments at the top of the file, but if someone wanted to use the closure compiler and the coffeescript plugin there would need to be a way to ensure that the closure compiler runs after the coffeescript compiler.

but figured this was a useful plugin even without that.  is there currently a system for specifying plugin run order?
