### PR TITLE
New plugin: blog_images

### DIFF
--- a/skeleton/plugins/blog_images.disabled.py
+++ b/skeleton/plugins/blog_images.disabled.py
@@ -1,0 +1,51 @@
+import os
+import logging
+
+POST_IMAGES_PATH = 'blog-post-images/'
+POST_IMAGES = {}
+POSTS_PATH = 'posts/'
+
+from cactus.utils import fileList
+from cactus.file import File
+
+def preBuild(site):
+    """
+    create a dict keyed on each post path.
+    each value of the dict is an array of paths pointing
+    to image filenames.
+    """
+    global POST_IMAGES
+
+    # grab all posts
+    posts = site.pages()
+    posts = filter(lambda x: x.path.startswith(POSTS_PATH), posts)
+
+    for page in posts:
+
+        # Skip non html posts for obious reasons
+        if not page.path.endswith('.html'):
+            continue
+
+        try:
+            post_filename = os.path.splitext(os.path.basename(page.path))[0]
+            images = fileList(os.path.join(site.paths['static'], POST_IMAGES_PATH + post_filename), relative=True)
+            POST_IMAGES[page.path] = []
+            for image in images:
+                image_path = POST_IMAGES_PATH + post_filename + "/" + image
+                POST_IMAGES[page.path].append(File(site,image_path))
+        except Exception, e:
+            logging.warning("Error processing blog images: %s" % e)
+
+
+def preBuildPage(site, page, context, data):
+    """
+    Add the list of posts to every page context so we can
+    access them from wherever on the site.
+    """
+    context['post_images'] = POST_IMAGES
+
+    for path in POST_IMAGES:
+        if path == page.path:
+            context['images'] = POST_IMAGES[path]
+
+    return context, data


### PR DESCRIPTION
Hi Koen,

I'm brand new to python, so please excuse any mistakes.

This is a new plugin (inspired by a similar one for docpad called "associated-images") that allows users of the blog.py plugin to place image files in a specially named directory within the static directory. For example:

Given the following file structure:

```
├── static
│   ├── blog-post-images
│   │   └── first-post
│   │       ├── 4torresBackyard.jpg
│   │       ├── BosqueTalladores_Panorama1.jpg
│   │       ├── ChillanSki_Panorama1.jpg
│   │       └── cachiPanorama.jpg
...
├── pages
│   ├── posts
│   │   ├── first-post.html
```

The plugin will allow you to load an array of image paths like so in any page:

```
{% for image in images %}
  <img src="{{ STATIC_URL }}/{{ image.path }}" alt="" />
{% endfor %}
```
