### PR TITLE
missing <html> open tag in skeleton base template

### DIFF
--- a/skeleton/templates/base.html
+++ b/skeleton/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-
+<html>
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
The base.html template is missing the opening `<html>` tag, this should fix it.
