### PR TITLE
Save existing AWS bucket name in config

### DIFF
--- a/cactus/site.py
+++ b/cactus/site.py
@@ -286,6 +286,7 @@ class Site(object):
 					awsBucket = b
 
 		self.config.set('aws-bucket-website', awsBucket.get_website_endpoint())
+		self.config.set('aws-bucket-name', awsBucketName)
 		self.config.write()
 		
 		logging.info('Uploading site to bucket %s' % awsBucketName)


### PR DESCRIPTION
Save the bucket name in the config even if we didn't create it. That way we don't need to enter it again and again with every deploy operation.
