### PR TITLE
Fix basic tests breaking based on order of files

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -37,8 +37,8 @@ class SimpleTest(unittest.TestCase):
 		self.site.bootstrap()
 		
 		self.assertEqual(
-			fileList(TEST_PATH, relative=True), 
-			fileList("skeleton", relative=True), 
+			set(fileList(TEST_PATH, relative=True)), 
+			set(fileList("skeleton", relative=True)), 
 		)
 
 
@@ -49,14 +49,17 @@ class SimpleTest(unittest.TestCase):
 		# Make sure we build to .build and not build
 		self.assertEqual(os.path.exists(os.path.join(TEST_PATH, 'build')), False)
 		
-		self.assertEqual(fileList(os.path.join(TEST_PATH, '.build'), relative=True), [
+		self.assertEqual(
+            set(fileList(os.path.join(TEST_PATH, '.build'), relative=True)), 
+            set([
 			'error.html',
 			'index.html',
 			'robots.txt',
 			'sitemap.xml',
 			'static/css/style.css',
-			'static/js/main.js'
-		])
+			'static/js/main.js' 
+            ])
+        )
 	
 	#def testRenderPage(self):
 		


### PR DESCRIPTION
The build tests were failing on my machine because the order of the
files was not the same within the test list and the actual file list. I
thought this to be an unintended side effect and converted the lists to
sets. I believe this was the intention.
