### PR TITLE
Windows fixes

### DIFF
--- a/cactus/site.py
+++ b/cactus/site.py
@@ -9,6 +9,7 @@ import imp
 import base64
 import traceback
 import socket
+import shutil
 import tempfile
 import tarfile
 import zipfile
@@ -155,17 +156,16 @@ class Site(object):
 	
 	def buildStatic(self):
 		"""
-		Move static files to build folder. To be fast we symlink it for now,
-		but we should actually copy these files in the future.
+		Copy static files to build folder.
 		"""
 		staticBuildPath = os.path.join(self.paths['build'], 'static')
-		
-		# If there is a folder, replace it with a symlink
-		if os.path.lexists(staticBuildPath) and not os.path.exists(staticBuildPath):
-			os.remove(staticBuildPath)
-		
-		if not os.path.lexists(staticBuildPath):
-			os.symlink(self.paths['static'], staticBuildPath)
+
+		# Delete existing static files in build folder
+		if os.path.exists(staticBuildPath):
+			shutil.rmtree(staticBuildPath)
+
+		# Copy static files to build folder
+		shutil.copytree(self.paths['static'], staticBuildPath)
 
 	def pages(self):
 		"""

--- a/skeleton/plugins/blog.disabled.py
+++ b/skeleton/plugins/blog.disabled.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 
 ORDER = 999
-POSTS_PATH = 'posts/'
+POSTS_PATH = 'posts' + os.sep
 POSTS = []
 
 from django.template import Context


### PR DESCRIPTION
We want to use Cactus on Windows for a client project. Most things seem to work right out of the box, except for two minor issues. 
- The first issue is the use of symlinks when preparing static files in the build folder, which isn't supported on Windows.
- The other is that the directory separator was hardcoded in a path string in the blog plugin.
