### PR TITLE
Reconciled robots.txt with protocol

### DIFF
--- a/skeleton/pages/robots.txt
+++ b/skeleton/pages/robots.txt
@@ -1,2 +1,6 @@
-{% for page in CACTUS.pages %}{% if page.path != 'error.html' %}{{ page.path }}
-{% endif %}{% endfor %}
+{% verbatim %}
+User-agent: *
+Disallow:
+
+Sitemap: sitemap.xml
+{% endverbatim %}


### PR DESCRIPTION
Reconciled robots.txt with Robots Exclusion Protocol. Defaults now specify that all pages are available and sitemap resides at /sitemap.xml.

See http://www.robotstxt.org/robotstxt.html and http://support.google.com/webmasters/bin/answer.py?hl=en&answer=183669 for more details.
