### PR TITLE
Universal Analytics plugin, with conditional inclusion in base.html

### DIFF
--- a/skeleton/plugins/analytics.disabled.py
+++ b/skeleton/plugins/analytics.disabled.py
@@ -1,0 +1,40 @@
+# Universal Analytics plug-in
+
+# How-To:
+# 1. Register for Google Universal Analytics and get a
+#       property ID.
+# 2. Replace GA_ID below with your Google Analytics property ID.
+# 3. Ensure that the {{ tracking }} block appears on your pages
+#       just before the end of the <head> section (it should
+#       hopefully be in base.html)
+
+GA_ID = 'UA-XXXXXXXX-X'
+
+# Tracking code template: DO NOT CHANGE unless you
+# know what you are doing
+GA_CODE = """
+        <script>
+          (function(i,s,o,g,r,a,m){{i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){{
+          (i[r].q=i[r].q||[]).push(arguments)}},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          }})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+          ga('create', '{0}');
+          ga('send', 'pageview');
+
+        </script>
+    """
+
+SNIPPET = ''
+
+def preBuild(site):
+
+    global SNIPPET
+
+    SNIPPET = GA_CODE.format(GA_ID)
+
+def preBuildPage(site, page, context, data):
+
+    context['universalAnalytics'] = SNIPPET
+
+    return context, data

--- a/skeleton/templates/base.html
+++ b/skeleton/templates/base.html
@@ -12,6 +12,10 @@
 	<title>Welcome</title>
 	{% endblock %}
 
+    {% if universalAnalytics %}{% autoescape off %}
+    {{ universalAnalytics }}
+    {% endautoescape %}{% endif %}
+
 </head>
 <body>
 	{% block content %}


### PR DESCRIPTION
This plugin is designed to include [Google Universal Analytics](https://developers.google.com/analytics/devguides/collection/analyticsjs/) tracking code for use in templates as `{{ universalAnalytics }}`. There are two requirements I needed it to fulfill:
1. Put the tracking code _on the page_, not in an included .js file.
2. Not mess up template files with a bunch of ugly tracking code.

...which is why it performs a trivial replacement and includes the tracking code in the script itself. It does require the user to open the script and enter their tracking ID.
