### PR TITLE
Added i18n support and the i18n lint tool to wrap the template strings in {% trans %} tags

### DIFF
--- a/cactus/cli.py
+++ b/cactus/cli.py
@@ -54,6 +54,7 @@ def help():
     print '    build: Rebuild your site from source files'
     print '    serve <port>: Serve you website at local development server'
     print '    deploy: Upload and deploy your site to S3'
+    print '    i18nlint: Add trans tags where needed or print strings that need them'
     print
 
 

--- a/cactus/cli.py
+++ b/cactus/cli.py
@@ -98,17 +98,35 @@ def main():
         deploy(os.getcwd())
 
     elif command == 'i18nlint':
-        parser = OptionParser(usage="usage: %prog [options] <filename>")
+        parser = OptionParser(usage="usage: %prog [options]")
         parser.add_option("-r", "--replace", action="store_true", dest="replace",
                 help="Ask to replace the strings in the file.", default=False)
+
+        parser.add_option("-f", "--filename", action="store", dest="filename",
+                help="Input one filename.", default=False)
         (options, args) = parser.parse_args()
-        if len(args) != 2:
-            parser.error("incorrect number of arguments")
         from i18nlint import replace_strings, print_strings
-        if options.replace:
-            replace_strings(args[1])
+
+        def run_i18nlint(filename):
+            if options.replace:
+                replace_strings(filename)
+            else:
+                print_strings(filename)
+
+        if options.filename:
+            run_i18nlint(options.filename)
         else:
-            print_strings(args[1])
+            for root, dirs, files in os.walk('pages'):
+                for name in files:
+                    if '.svn' not in root:
+                        if 'html' in name and '_translated' not in name:
+                            change = raw_input("Run i18nlint on file '%s/%s'? [Y/n] " % (root, name))
+                            if change == 'y' or change == "":
+                                run_i18nlint(os.path.join(root, name))
+
+        if len(args) > 2:
+            print "ERROR: Too many arguments"
+            help()
 
     else:
         print 'Unknown command: %s' % command

--- a/cactus/cli.py
+++ b/cactus/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
+from optparse import OptionParser
 
 import sys
 import os
@@ -7,91 +8,111 @@ import time
 
 import cactus
 
+
 def create(path):
-	"Creates a new project at the given path."
-	
-	if os.path.exists(path):
-		if raw_input('Path %s exists, move aside (y/n): ' % path) == 'y':
-			os.rename(path, '%s.%s.moved' % (path, int(time.time())))
-		else:
-			sys.exit()
-	
-	site = cactus.Site(path)
-	site.bootstrap()
+    "Creates a new project at the given path."
+
+    if os.path.exists(path):
+        if raw_input('Path %s exists, move aside (y/n): ' % path) == 'y':
+            os.rename(path, '%s.%s.moved' % (path, int(time.time())))
+        else:
+            sys.exit()
+
+    site = cactus.Site(path)
+    site.bootstrap()
 
 
 def build(path):
-	"Build a cactus project"
-	
-	site = cactus.Site(path)
-	site.verify()
-	site.build()
+    "Build a cactus project"
+
+    site = cactus.Site(path)
+    site.verify()
+    site.build()
+
 
 def serve(path, port=8000, browser=True):
-	"Serve the project and watch changes"
-	
-	site = cactus.Site(path)
-	site.verify()
-	site.serve(port=port, browser=browser)
+    "Serve the project and watch changes"
+
+    site = cactus.Site(path)
+    site.verify()
+    site.serve(port=port, browser=browser)
+
 
 def deploy(path):
-	"Upload the project to S3"
-	
-	site = cactus.Site(path)
-	site.verify()
-	site.upload()
+    "Upload the project to S3"
+
+    site = cactus.Site(path)
+    site.verify()
+    site.upload()
+
 
 def help():
-	print
-	print 'Usage: cactus [create|build|serve|deploy]'
-	print
-	print '    create: Create a new website skeleton at path'
-	print '    build: Rebuild your site from source files'
-	print '    serve <port>: Serve you website at local development server'
-	print '    deploy: Upload and deploy your site to S3'
-	print
+    print
+    print 'Usage: cactus [create|build|serve|deploy|i18nlint]'
+    print
+    print '    create: Create a new website skeleton at path'
+    print '    build: Rebuild your site from source files'
+    print '    serve <port>: Serve you website at local development server'
+    print '    deploy: Upload and deploy your site to S3'
+    print
+
 
 def exit(msg):
-	print msg
-	sys.exit()
+    print msg
+    sys.exit()
+
 
 def main():
-	
-	command = sys.argv[1] if len(sys.argv) > 1 else None
-	option1 = sys.argv[2] if len(sys.argv) > 2 else None
-	option2 = sys.argv[3] if len(sys.argv) > 3 else None
-	
-	# If we miss a command we exit and print help
-	if not command:
-		help()
-		sys.exit()
+    command = sys.argv[1] if len(sys.argv) > 1 else None
+    option1 = sys.argv[2] if len(sys.argv) > 2 else None
+    option2 = sys.argv[3] if len(sys.argv) > 3 else None
 
-	# Run the command
-	if command == 'create':
-		if not option1: exit('Missing path')
-		create(option1)
+    # If we miss a command we exit and print help
+    if not command:
+        help()
+        sys.exit()
 
-	elif command == 'build':
-		build(os.getcwd())
+    # Run the command
+    if command == 'create':
+        if not option1: exit('Missing path')
+        create(option1)
 
-	elif command == 'serve':
-		
-		if option1:
-			try: option1 = int(option1)
-			except: exit('port should be a round number like 5000, 8000, 8080')
-		else:
-			option1 = 8000
+    elif command == 'build':
+        build(os.getcwd())
 
-		browser = False if option2 == '-n' else True
+    elif command == 'serve':
 
-		serve(os.getcwd(), port=option1, browser=browser)
+        if option1:
+            try:
+                option1 = int(option1)
+            except:
+                exit('port should be a round number like 5000, 8000, 8080')
+        else:
+            option1 = 8000
 
-	elif command == 'deploy':
-		deploy(os.getcwd())
+        browser = False if option2 == '-n' else True
 
-	else:
-		print 'Unknown command: %s' % command
-		help()
+        serve(os.getcwd(), port=option1, browser=browser)
+
+    elif command == 'deploy':
+        deploy(os.getcwd())
+
+    elif command == 'i18nlint':
+        parser = OptionParser(usage="usage: %prog [options] <filename>")
+        parser.add_option("-r", "--replace", action="store_true", dest="replace",
+                help="Ask to replace the strings in the file.", default=False)
+        (options, args) = parser.parse_args()
+        if len(args) != 2:
+            parser.error("incorrect number of arguments")
+        from i18nlint import replace_strings, print_strings
+        if options.replace:
+            replace_strings(args[1])
+        else:
+            print_strings(args[1])
+
+    else:
+        print 'Unknown command: %s' % command
+        help()
 
 if __name__ == "__main__":
-	sys.exit(main())
+    sys.exit(main())

--- a/cactus/i18nlint.py
+++ b/cactus/i18nlint.py
@@ -111,7 +111,7 @@ def replace_strings(filename):
 
     full_text = "".join(full_text_lines)
     os.rename = (filename, filename.split(".")[0] + "_orig.html")
-    save_filename = filename.split(".")
+    save_filename = filename
     open(save_filename, 'w').write(full_text)
     print "Fully translated! Saved as: %s" % save_filename
 

--- a/cactus/i18nlint.py
+++ b/cactus/i18nlint.py
@@ -4,6 +4,7 @@ Prints out all
 """
 
 import re
+import os
 import sys
 from optparse import OptionParser
 
@@ -109,7 +110,8 @@ def replace_strings(filename):
         full_text_lines.append(message)
 
     full_text = "".join(full_text_lines)
-    save_filename = filename.split(".")[0] + "_translated.html"
+    os.rename = (filename, filename.split(".")[0] + "_orig.html")
+    save_filename = filename.split(".")
     open(save_filename, 'w').write(full_text)
     print "Fully translated! Saved as: %s" % save_filename
 

--- a/cactus/i18nlint.py
+++ b/cactus/i18nlint.py
@@ -1,0 +1,137 @@
+#! /usr/bin/python
+"""
+Prints out all
+"""
+
+import re
+import sys
+from optparse import OptionParser
+
+
+def location(str, pos):
+    """Given a string str and an integer pos, find the line number and character in that line that correspond to pos"""
+    lineno, charpos = 1, 1
+    counter = 0
+    for char in str:
+        if counter == pos:
+            return lineno, charpos
+        elif char == '\n':
+            lineno += 1
+            charpos = 1
+            counter += 1
+        else:
+            charpos += 1
+            counter += 1
+
+    return lineno, charpos
+
+# Things that are OK:
+GOOD_STRINGS = re.compile(
+    r"""
+          # django comment
+       ( {%\ comment\ %}.*?{%\ endcomment\ %}
+
+         # already translated text
+        |{%\ ?blocktrans.*?{%\ ?endblocktrans\ ?%}
+
+         # any django template function (catches {% trans ..) aswell
+        |{%.*?%}
+
+         # CSS
+        |<style.*?</style>
+
+         # JS
+        |<script.*?</script>
+
+         # A html title or value attribute that's been translated
+        |(?:value|title|summary|alt)="{%\ ?trans.*?%}"
+
+         # A html title or value attribute that's just a template var
+        |(?:value|title|summary|alt)="{{.*?}}"
+
+         # An <option> value tag
+        |<option[^<>]+?value="[^"]*?"
+
+         # Any html attribute that's not value or title
+        |[a-z:-]+?(?<!alt)(?<!value)(?<!title)(?<!summary)='[^']*?'
+
+         # Any html attribute that's not value or title
+        |[a-z:-]+?(?<!alt)(?<!value)(?<!title)(?<!summary)="[^"]*?"
+
+         # HTML opening tag
+        |<[\w:]+
+
+         # End of a html opening tag
+        |>
+        |/>
+
+         # closing html tag
+        |</.*?>
+
+         # any django template variable
+        |{{.*?}}
+
+         # HTML doctype
+        |<!DOCTYPE.*?>
+
+         # IE specific HTML
+        |<!--\[if.*?<!\[endif\]-->
+
+         # HTML comment
+        |<!--.*?-->
+
+         # HTML entities
+        |&[a-z]{1,10};
+
+         # CSS style
+        |<style.*?</style>
+
+         # another common template comment
+        |{\#.*?\#}
+        )""",
+
+    # MULTILINE to match across lines and DOTALL to make . include the newline
+    re.MULTILINE|re.DOTALL|re.VERBOSE)
+
+# Stops us matching non-letter parts, e.g. just hypens, full stops etc.
+LETTERS = re.compile("\w")
+
+
+def replace_strings(filename):
+    full_text_lines = []
+    for index, message in enumerate(GOOD_STRINGS.split(open(filename).read())):
+        if index % 2 == 0 and re.search("\w", message):
+            before, message, after = re.match("^(\s*)(.*?)(\s*)$", message, re.DOTALL).groups()
+            message = message.strip().replace("\n", "").replace("\r", "")
+            change = raw_input("Make '%s' translatable? [Y/n] " % message)
+            if change == 'y' or change == "":
+                message = '%s{%% trans "%s" %%}%s' % (before, message, after)
+        full_text_lines.append(message)
+
+    full_text = "".join(full_text_lines)
+    save_filename = filename.split(".")[0] + "_translated.html"
+    open(save_filename, 'w').write(full_text)
+    print "Fully translated! Saved as: %s" % save_filename
+
+
+def non_translated_text(filename):
+
+    template = open(filename).read()
+    offset = 0
+
+    # Find the parts of the template that don't match this regex
+    # taken from http://www.technomancy.org/python/strings-that-dont-match-regex/
+    for index, match in enumerate(GOOD_STRINGS.split(template)):
+        if index % 2 == 0:
+
+            # Ignore it if it doesn't have letters
+            if LETTERS.search(match):
+                lineno, charpos = location(template, offset)
+                yield (lineno, charpos, match.strip().replace("\n", "").replace("\r", "")[:120])
+
+        offset += len(match)
+
+
+def print_strings(filename):
+    for lineno, charpos, message in non_translated_text(filename):
+        print "%s:%s:%s:%s" % (filename, lineno, charpos, message)

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -39,7 +39,7 @@ class Page(object):
         context = dict(self.site._contextCache)
 
         # Relative url context
-        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')) - 1)]) or '.'
+        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')))]) or '..'
 
         context.update({
         'STATIC_URL': os.path.join(prefix, 'static'),

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -1,87 +1,104 @@
 import os
 import codecs
 import logging
+from django.utils.translation import activate
 
 from .utils import parseValues
 
 from django.template import Template, Context
 from django.template import loader as templateLoader
 
+
 class Page(object):
-	
-	def __init__(self, site, path):
-		self.site = site
-		self.path = path
+    def __init__(self, site, path):
+        self.site = site
+        self.path = path
 
-		self.paths = {
-			'full': os.path.join(self.site.path, 'pages', self.path),
-			# 'build': os.path.join('.build', self.path),
-			'full-build': os.path.join(site.paths['build'], self.path),
-		}
-		
-	def data(self):
-		f = codecs.open(self.paths['full'], 'r', 'utf-8')
-		data = f.read()
-		f.close()
-		return data
-	
-	def context(self):
-		"""
-		The page context.
-		"""
-		
-                # Site context, making a shallow-copy using dict so that the
-                # things we add to this page's context below won't be added to
-                # the site's context. if in the future we make non-top-level
-                # changes to the page's context the shallow copy won't be
-                # enough, we'd need to look at copy.deepcopy
-		context = dict(self.site._contextCache)
-		
-		# Relative url context
-		prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')) - 1)]) or '.'
-		
-		context.update({
-			'STATIC_URL': os.path.join(prefix, 'static'),
-			'ROOT_URL': prefix,
-		})
-		
-		# Page context (parse header)
-		context.update(parseValues(self.data())[0])
-		
-		return Context(context)
+        self.paths = {
+        'full': os.path.join(self.site.path, 'pages', self.path),
+        # 'build': os.path.join('.build', self.path),
+        'full-build': os.path.join(site.paths['build'], self.path),
+        }
 
-	def render(self):
-		"""
-		Takes the template data with contect and renders it to the final output file.
-		"""
-		
-		data = parseValues(self.data())[1]
-		context = self.context()
-		
-		# Run the prebuild plugins, we can't use the standard method here because
-		# plugins can chain-modify the context and data.
-		for plugin in self.site._plugins:
-			if hasattr(plugin, 'preBuildPage'):
-				context, data = plugin.preBuildPage(self.site, self, context, data)
+    def data(self):
+        f = codecs.open(self.paths['full'], 'r', 'utf-8')
+        data = f.read()
+        f.close()
+        return data
 
-		return Template(data).render(context)
+    def context(self):
+        """
+        The page context.
+        """
 
-	def build(self):
-		"""
-		Save the rendered output to the output file.
-		"""
-		logging.info("Building %s", self.path)
-		
-		data = self.render()
-		
-		# Make sure a folder for the output path exists
-		try: os.makedirs(os.path.dirname(self.paths['full-build']))
-		except OSError: pass
-		
-		# Write the data to the output file
-		f = codecs.open(self.paths['full-build'], 'w', 'utf-8')
-		f.write(data)
-		f.close()
-		
-		# Run all plugins
-		self.site.pluginMethod('postBuildPage', self.site, self.paths['full-build'])
+        # Site context, making a shallow-copy using dict so that the
+        # things we add to this page's context below won't be added to
+        # the site's context. if in the future we make non-top-level
+        # changes to the page's context the shallow copy won't be
+        # enough, we'd need to look at copy.deepcopy
+        context = dict(self.site._contextCache)
+
+        # Relative url context
+        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')) - 1)]) or '.'
+
+        context.update({
+        'STATIC_URL': os.path.join('/', 'static'),
+        'ROOT_URL': prefix,
+        })
+
+        # Page context (parse header)
+        context.update(parseValues(self.data())[0])
+
+        return Context(context)
+
+    def render(self):
+        """
+        Takes the template data with contect and renders it to the final output file.
+        """
+
+        data = parseValues(self.data())[1]
+        context = self.context()
+
+        # Run the prebuild plugins, we can't use the standard method here because
+        # plugins can chain-modify the context and data.
+        for plugin in self.site._plugins:
+            if hasattr(plugin, 'preBuildPage'):
+                context, data = plugin.preBuildPage(self.site, self, context, data)
+
+        return Template(data).render(context)
+
+    def build(self):
+        """
+        Save the rendered output to the output file.
+        """
+        def render_write(self):
+            data = self.render()
+
+            # Make sure a folder for the output path exists
+            try:
+                os.makedirs(os.path.dirname(self.paths['full-build']))
+            except OSError:
+                pass
+
+            # Write the data to the output file
+            f = codecs.open(self.paths['full-build'], 'w', 'utf-8')
+            f.write(data)
+            f.close()
+
+        logging.info("Building %s", self.path)
+
+        locale_dir = os.path.join(self.site.path, 'conf', 'locale')
+        if os.path.isdir(locale_dir):
+            for locale in os.listdir(locale_dir):
+                if os.path.isdir(os.path.join(locale_dir, locale)) and not locale.startswith("."):
+                    activate(locale)
+                    logging.info("Building %s %s" % (locale, self.path))
+                    self.paths['full-build'] = os.path.join(self.site.paths['build'], locale, self.path)
+                    render_write(self)
+
+        render_write(self)
+
+        # Run all plugins
+        self.site.pluginMethod('postBuildPage', self.site, self.paths['full-build'])
+
+

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -39,10 +39,10 @@ class Page(object):
         context = dict(self.site._contextCache)
 
         # Relative url context
-        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')) - 1)]) or '.'
+        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')))]) or '..'
 
         context.update({
-        'STATIC_URL': os.path.join('/', 'static'),
+        'STATIC_URL': os.path.join(prefix, 'static'),
         'ROOT_URL': prefix,
         })
 

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -39,7 +39,7 @@ class Page(object):
         context = dict(self.site._contextCache)
 
         # Relative url context
-        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')))]) or '..'
+        prefix = '/'.join(['..' for i in xrange(len(self.path.split('/')) - 1)]) or '.'
 
         context.update({
         'STATIC_URL': os.path.join(prefix, 'static'),

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -13,8 +13,10 @@ import tempfile
 import tarfile
 import zipfile
 import urllib
+import distutils
 
 import boto
+from django.conf.global_settings import gettext_noop, LANGUAGES
 
 from .config import Config
 from .utils import *
@@ -26,385 +28,405 @@ from .browser import browserReload, browserReloadCSS
 
 
 class Site(object):
-	
-	def __init__(self, path):
-		
-		self.path = path
+    def __init__(self, path):
 
-		self.paths = {
-			'config': os.path.join(path, 'config.json'),
-			'build': os.path.join(path, '.build'),
-			'pages': os.path.join(path, 'pages'),
-			'templates': os.path.join(path, 'templates'),
-			'plugins': os.path.join(path, 'plugins'),
-			'static': os.path.join(path, 'static'),
-            'locales': os.path.join(path, 'conf', 'locale'),
-			'script': os.path.join(os.getcwd(), __file__)
-		}
-		
-		self.config = Config(self.paths['config'])
-	
-	def setup(self):
-		"""
-		Configure django to use both our template and pages folder as locations
-		to look for included templates.
-		"""
-		try:
-			from django.conf import settings
-			settings.configure(
-				TEMPLATE_DIRS=[self.paths['templates'], self.paths['pages']],
-				INSTALLED_APPS=['django.contrib.markup'],
-                LOCALE_PATHS=[self.paths['locales'],],
-			)
-		except:
-			pass
-	
-	def verify(self):
-		"""
-		Check if this path looks like a Cactus website
-		"""
-		for p in ['pages', 'static', 'templates', 'plugins']:
-			if not os.path.isdir(os.path.join(self.path, p)):
-				logging.info('This does not look like a (complete) cactus project (missing "%s" subfolder)', p)
-				sys.exit()
-	
-	def bootstrap(self, skeleton=None):
-		"""
-		Bootstrap a new project at a given path. If provided, the skeleton argument will be used as the basis for the new cactus project, in place of the default skeleton. If provided, the argument can be a filesystem path to a directory, a tarfile, a zipfile, or a URL which retrieves a tarfile or a zipfile.
-		"""
-		
-		skeletonArchive = skeletonFile = None
-		if skeleton is None:
-			from .skeleton import data
-			logging.info("Building from data")
-			temp = tempfile.NamedTemporaryFile(delete=False, suffix='.tar.gz')
-			temp.write(base64.b64decode(data))
-			temp.close()
-			skeletonArchive = tarfile.open(name=temp.name, mode='r')
-		elif os.path.isfile(skeleton):
-			skeletonFile = skeleton
-		else: 
-			# Assume it's a URL
-			skeletonFile, headers = urllib.urlretrieve(skeleton)
+        self.path = path
 
-		if skeletonFile:
-			if tarfile.is_tarfile(skeletonFile):
-				skeletonArchive = tarfile.open(name=skeletonFile, mode='r')
-			elif zipfile.is_zipfile(skeletonFile):
-				skeletonArchive = zipfile.ZipFile(skeletonFile)
-			else:
-				logging.error("File %s is an unknown file archive type. At this time, skeleton argument must be a directory, a zipfile, or a tarball." % skeletonFile)
-				sys.exit()
+        self.paths = {
+        'config': os.path.join(path, 'config.json'),
+        'build': os.path.join(path, '.build'),
+        'pages': os.path.join(path, 'pages'),
+        'templates': os.path.join(path, 'templates'),
+        'plugins': os.path.join(path, 'plugins'),
+        'static': os.path.join(path, 'static'),
+        'locales': os.path.join(path, 'conf', 'locale'),
+        'script': os.path.join(os.getcwd(), __file__)
+        }
 
-		if skeletonArchive:
-			os.mkdir(self.path)
-			skeletonArchive.extractall(path=self.path)
-			skeletonArchive.close()
-			logging.info('New project generated at %s', self.path)
-		elif os.path.isdir(skeleton):
-			shutil.copytree(skeleton, self.path)
-			logging.info('New project generated at %s', self.path)
-		else:
-			logging.error("Cannot process skeleton '%s'. At this time, skeleton argument must be a directory, a zipfile, or a tarball." % skeleton)
+        self.config = Config(self.paths['config'])
 
-	def context(self):
-		"""
-		Base context for the site: all the html pages.
-		"""
-		return {'CACTUS': {'pages': [p for p in self.pages() if p.path.endswith('.html')]}}
-	
-	def clean(self):
-		"""
-		Remove all build files.
-		"""
-		if os.path.isdir(self.paths['build']):
-			shutil.rmtree(self.paths['build'])
-	
-	def build(self):
-		"""
-		Generate fresh site from templates.
-		"""
+    def setup(self):
+        """
+        Configure django to use both our template and pages folder as locations
+        to look for included templates.
+        """
+        try:
+            from django.conf import settings
 
-		# Set up django settings
-		self.setup()
+            settings.configure(
+                TEMPLATE_DIRS=[self.paths['templates'], self.paths['pages']],
+                INSTALLED_APPS=['django.contrib.markup'],
+                LOCALE_PATHS=[self.paths['locales'], ],
+                LANGUAGE_CODE= 'en-us',
+                #LANGUAGES=LANGUAGES + (('en-us', gettext_noop('US English')),)
+            )
+        except:
+            pass
 
-		# Bust the context cache
-		self._contextCache = self.context()
-		
-		# Load the plugin code, because we want fresh plugin code on build
-		# refreshes if we're running the web server with listen.
-		self.loadPlugins()
-		
-		logging.info('Plugins: %s', ', '.join([p.id for p in self._plugins]))
+    def verify(self):
+        """
+        Check if this path looks like a Cactus website
+        """
+        for p in ['pages', 'static', 'templates', 'plugins']:
+            if not os.path.isdir(os.path.join(self.path, p)):
+                logging.info('This does not look like a (complete) cactus project (missing "%s" subfolder)', p)
+                sys.exit()
 
-		self.pluginMethod('preBuild', self)
-		
-		# Make sure the build path exists
-		if not os.path.exists(self.paths['build']):
-			os.mkdir(self.paths['build'])
-		
-		# Copy the static files
-		self.buildStatic()
-		
-		# Render the pages to their output files
-		
-		# Comment for non threaded building, crashes randomly
-		multiMap = map
-		
-		multiMap(lambda p: p.build(), self.pages())
-		
-		self.pluginMethod('postBuild', self)
-	
-	def buildStatic(self):
-		"""
-		Move static files to build folder. To be fast we symlink it for now,
-		but we should actually copy these files in the future.
-		"""
-		staticBuildPath = os.path.join(self.paths['build'], 'static')
-		
-		# If there is a folder, replace it with a symlink
-		if os.path.lexists(staticBuildPath) and not os.path.exists(staticBuildPath):
-			os.remove(staticBuildPath)
-		
-		if not os.path.lexists(staticBuildPath):
-			os.symlink(self.paths['static'], staticBuildPath)
-	
-	def ignorePatterns(self):
-		
-		# Page filters
-		defaultPatterns = [".*", "*~"]
-		configPatterns  = self.config.get("ignore")
-		
-		# Add the config values to the default ignore list
-		if type(configPatterns) is types.ListType:
-			defaultPatterns += configPatterns
-		
-		return defaultPatterns
-	
-	def pages(self):
-		"""
-		List of pages.
-		"""
-		
-		paths = fileList(self.paths['pages'], relative=True)
+    def bootstrap(self, skeleton=None):
+        """
+        Bootstrap a new project at a given path. If provided, the skeleton argument will be used as the basis for the new cactus project, in place of the default skeleton. If provided, the argument can be a filesystem path to a directory, a tarfile, a zipfile, or a URL which retrieves a tarfile or a zipfile.
+        """
 
-		# Filter out the ignored paths
-		paths = filterPaths(paths, self.ignorePatterns())
-		
-		return [Page(self, p) for p in paths]
+        skeletonArchive = skeletonFile = None
+        if skeleton is None:
+            from .skeleton import data
 
-	def serve(self, browser=True, port=8000):
-		"""
-		Start a http server and rebuild on changes.
-		"""
-		self.clean()
-		self.build()
-	
-		logging.info('Running webserver at 0.0.0.0:%s for %s' % (port, self.paths['build']))
-		logging.info('Type control-c to exit')
-	
-		os.chdir(self.paths['build'])
-		
-		def rebuild(changes):
-			logging.info('*** Rebuilding (%s changed)' % self.path)
-			
-			# We will pause the listener while building so scripts that alter the output
-			# like coffeescript and less don't trigger the listener again immediately.
-			self.listener.pause()
-			try: self.build()
-			except Exception, e: 
-				logging.info('*** Error while building\n%s', e)
-				traceback.print_exc(file=sys.stdout)
-			
-			# When we have changes, we want to refresh the browser tabs with the updates.
-			# Mostly we just refresh the browser except when there are just css changes,
-			# then we reload the css in place.
-			if  len(changes["added"]) == 0 and \
-				len(changes["deleted"]) == 0 and \
-				set(map(lambda x: os.path.splitext(x)[1], changes["changed"])) == set([".css"]):
-				browserReloadCSS('http://127.0.0.1:%s' % port)
-			else:
-				browserReload('http://127.0.0.1:%s' % port)
-			
-			self.listener.resume()
-	
-		self.listener = Listener(self.path, rebuild, ignore=lambda x: '/.build/' in x)
-		self.listener.run()
-		
-		try:
-			httpd = Server(("", port), RequestHandler)
-		except socket.error, e:
-			logging.info('Could not start webserver, port is in use. To use another port:')
-			logging.info('  cactus serve %s' % (int(port) + 1))
-			return
-		
-		if browser is True:
-			webbrowser.open('http://127.0.0.1:%s' % port)
+            logging.info("Building from data")
+            temp = tempfile.NamedTemporaryFile(delete=False, suffix='.tar.gz')
+            temp.write(base64.b64decode(data))
+            temp.close()
+            skeletonArchive = tarfile.open(name=temp.name, mode='r')
+        elif os.path.isfile(skeleton):
+            skeletonFile = skeleton
+        else:
+        # Assume it's a URL
+            skeletonFile, headers = urllib.urlretrieve(skeleton)
 
-		try: 
-			httpd.serve_forever() 
-		except (KeyboardInterrupt, SystemExit):
-			httpd.server_close() 
+        if skeletonFile:
+            if tarfile.is_tarfile(skeletonFile):
+                skeletonArchive = tarfile.open(name=skeletonFile, mode='r')
+            elif zipfile.is_zipfile(skeletonFile):
+                skeletonArchive = zipfile.ZipFile(skeletonFile)
+            else:
+                logging.error(
+                    "File %s is an unknown file archive type. At this time, skeleton argument must be a directory, a zipfile, or a tarball." % skeletonFile)
+                sys.exit()
 
-		logging.info('See you!')
+        if skeletonArchive:
+            os.mkdir(self.path)
+            skeletonArchive.extractall(path=self.path)
+            skeletonArchive.close()
+            logging.info('New project generated at %s', self.path)
+        elif os.path.isdir(skeleton):
+            shutil.copytree(skeleton, self.path)
+            logging.info('New project generated at %s', self.path)
+        else:
+            logging.error(
+                "Cannot process skeleton '%s'. At this time, skeleton argument must be a directory, a zipfile, or a tarball." % skeleton)
 
-	
-	def upload(self):
-		"""
-		Upload the site to the server.
-		"""
+    def context(self):
+        """
+        Base context for the site: all the html pages.
+        """
+        return {'CACTUS': {'pages': [p for p in self.pages() if p.path.endswith('.html')]}}
 
-		# Make sure we have internet
-		if not internetWorking():
-			logging.info('There does not seem to be internet here, check your connection')
-			return
+    def clean(self):
+        """
+        Remove all build files.
+        """
+        if os.path.isdir(self.paths['build']):
+            shutil.rmtree(self.paths['build'])
 
-		logging.debug('Start upload')
-		
-		self.clean()
-		self.build()
-		
-		logging.debug('Start preDeploy')
-		self.pluginMethod('preDeploy', self)
-		logging.debug('End preDeploy')
-		
-		# Get access information from the config or the user
-		awsAccessKey = self.config.get('aws-access-key') or \
-			raw_input('Amazon access key (http://bit.ly/Agl7A9): ').strip()
-		awsSecretKey = getpassword('aws', awsAccessKey) or \
-			getpass._raw_input('Amazon secret access key (will be saved in keychain): ').strip()
-		
-		# Try to fetch the buckets with the given credentials
-		connection = boto.connect_s3(awsAccessKey.strip(), awsSecretKey.strip())
-		
-		logging.debug('Start get_all_buckets')
-		# Exit if the information was not correct
-		try:
-			buckets = connection.get_all_buckets()
-		except:
-			logging.info('Invalid login credentials, please try again...')
-			return
-		logging.debug('end get_all_buckets')
-		
-		# If it was correct, save it for the future
-		self.config.set('aws-access-key', awsAccessKey)
-		self.config.write()
-	
-		setpassword('aws', awsAccessKey, awsSecretKey)
-	
-		awsBucketName = self.config.get('aws-bucket-name') or \
-			raw_input('S3 bucket name (www.yoursite.com): ').strip().lower()
-	
-		if awsBucketName not in [b.name for b in buckets]:
-			if raw_input('Bucket does not exist, create it? (y/n): ') == 'y':
-				
-				logging.debug('Start create_bucket')
-				try:
-					awsBucket = connection.create_bucket(awsBucketName, policy='public-read')
-				except boto.exception.S3CreateError, e:
-					logging.info('Bucket with name %s already is used by someone else, please try again with another name' % awsBucketName)
-					return
-				logging.debug('end create_bucket')
-				
-				# Configure S3 to use the index.html and error.html files for indexes and 404/500s.
-				awsBucket.configure_website('index.html', 'error.html')
+    def build(self):
+        """
+        Generate fresh site from templates.
+        """
 
-				self.config.set('aws-bucket-website', awsBucket.get_website_endpoint())
-				self.config.set('aws-bucket-name', awsBucketName)
-				self.config.write()
+        # Set up django settings
+        self.setup()
 
-				logging.info('Bucket %s was selected with website endpoint %s' % (self.config.get('aws-bucket-name'), self.config.get('aws-bucket-website')))
-				logging.info('You can learn more about s3 (like pointing to your own domain) here: https://github.com/koenbok/Cactus')
+        # Bust the context cache
+        self._contextCache = self.context()
+
+        # Load the plugin code, because we want fresh plugin code on build
+        # refreshes if we're running the web server with listen.
+        self.loadPlugins()
+
+        logging.info('Plugins: %s', ', '.join([p.id for p in self._plugins]))
+
+        self.pluginMethod('preBuild', self)
+
+        # Make sure the build path exists
+        if not os.path.exists(self.paths['build']):
+            os.mkdir(self.paths['build'])
+
+        # Copy the static files
+        self.buildStatic()
+
+        # Render the pages to their output files
+
+        # Comment for non threaded building, crashes randomly
+        multiMap = map
+
+        multiMap(lambda p: p.build(), self.pages())
+
+        self.pluginMethod('postBuild', self)
+
+    def buildStatic(self):
+        """
+        Move static files to build folder. To be fast we symlink it for now,
+        but we should actually copy these files in the future.
+        """
+        staticBuildPath = os.path.join(self.paths['build'], 'static')
+        for path, dirs, files in os.walk(self.paths['static'], topdown=True):
+            if '.svn' in dirs:
+                dirs.remove('.svn')
+            if '.DS_Store' in files:
+                files.remove('.DS_Store')
+            dest_path = path.replace(self.paths['static'], staticBuildPath)
+            for file in files:
+                shutil.copy(os.path.join(path, file), os.path.join(dest_path, file))
 
 
-			else: return
-		else:
-			
-			# Grab a reference to the existing bucket
-			for b in buckets:
-				if b.name == awsBucketName:
-					awsBucket = b
+        # If there is a folder, replace it with a copy
+        # if os.path.exists(staticBuildPath):
+        #     print "Removing %s" % staticBuildPath
+        #     shutil.rmtree(staticBuildPath)
+        #
+        # if not os.path.exists(staticBuildPath):
+        #     shutil.copytree(self.paths['static'], staticBuildPath, ignore=shutil.ignore_patterns('*.svn'))
 
-		self.config.set('aws-bucket-website', awsBucket.get_website_endpoint())
-		self.config.set('aws-bucket-name', awsBucketName)
-		self.config.write()
-		
-		logging.info('Uploading site to bucket %s' % awsBucketName)
-		
-		# Upload all files concurrently in a thread pool
-		totalFiles = multiMap(lambda p: p.upload(awsBucket), self.files())
-		changedFiles = [r for r in totalFiles if r['changed'] == True]
-		
-		self.pluginMethod('postDeploy', self)
-		
-		# Display done message and some statistics
-		logging.info('\nDone\n')
-		
-		logging.info('%s total files with a size of %s' % \
-			(len(totalFiles), fileSize(sum([r['size'] for r in totalFiles]))))
-		logging.info('%s changed files with a size of %s' % \
-			(len(changedFiles), fileSize(sum([r['size'] for r in changedFiles]))))
-		
-		logging.info('\nhttp://%s\n' % self.config.get('aws-bucket-website'))
+    def ignorePatterns(self):
+
+        # Page filters
+        defaultPatterns = [".*", "*~"]
+        configPatterns = self.config.get("ignore")
+
+        # Add the config values to the default ignore list
+        if type(configPatterns) is types.ListType:
+            defaultPatterns += configPatterns
+
+        return defaultPatterns
+
+    def pages(self):
+        """
+        List of pages.
+        """
+
+        paths = fileList(self.paths['pages'], relative=True)
+
+        # Filter out the ignored paths
+        paths = filterPaths(paths, self.ignorePatterns())
+
+        return [Page(self, p) for p in paths]
+
+    def serve(self, browser=True, port=8000):
+        """
+        Start a http server and rebuild on changes.
+        """
+        self.clean()
+        self.build()
+
+        logging.info('Running webserver at 0.0.0.0:%s for %s' % (port, self.paths['build']))
+        logging.info('Type control-c to exit')
+
+        os.chdir(self.paths['build'])
+
+        def rebuild(changes):
+            logging.info('*** Rebuilding (%s changed)' % self.path)
+
+            # We will pause the listener while building so scripts that alter the output
+            # like coffeescript and less don't trigger the listener again immediately.
+            self.listener.pause()
+            try:
+                self.build()
+            except Exception, e:
+                logging.info('*** Error while building\n%s', e)
+                traceback.print_exc(file=sys.stdout)
+
+            # When we have changes, we want to refresh the browser tabs with the updates.
+            # Mostly we just refresh the browser except when there are just css changes,
+            # then we reload the css in place.
+            if len(changes["added"]) == 0 and \
+                            len(changes["deleted"]) == 0 and \
+                            set(map(lambda x: os.path.splitext(x)[1], changes["changed"])) == set([".css"]):
+                browserReloadCSS('http://127.0.0.1:%s' % port)
+            else:
+                browserReload('http://127.0.0.1:%s' % port)
+
+            self.listener.resume()
+
+        self.listener = Listener(self.path, rebuild, ignore=lambda x: '/.build/' in x)
+        self.listener.run()
+
+        try:
+            httpd = Server(("", port), RequestHandler)
+        except socket.error, e:
+            logging.info('Could not start webserver, port is in use. To use another port:')
+            logging.info('  cactus serve %s' % (int(port) + 1))
+            return
+
+        if browser is True:
+            webbrowser.open('http://127.0.0.1:%s' % port)
+
+        try:
+            httpd.serve_forever()
+        except (KeyboardInterrupt, SystemExit):
+            httpd.server_close()
+
+        logging.info('See you!')
 
 
-	def files(self):
-		"""
-		List of build files.
-		"""
-		
-		paths = fileList(self.paths['build'], relative=True)
-		paths = filterPaths(paths, self.ignorePatterns())
-		
-		return [File(self, p) for p in paths]
+    def upload(self):
+        """
+        Upload the site to the server.
+        """
+
+        # Make sure we have internet
+        if not internetWorking():
+            logging.info('There does not seem to be internet here, check your connection')
+            return
+
+        logging.debug('Start upload')
+
+        self.clean()
+        self.build()
+
+        logging.debug('Start preDeploy')
+        self.pluginMethod('preDeploy', self)
+        logging.debug('End preDeploy')
+
+        # Get access information from the config or the user
+        awsAccessKey = self.config.get('aws-access-key') or \
+                       raw_input('Amazon access key (http://bit.ly/Agl7A9): ').strip()
+        awsSecretKey = getpassword('aws', awsAccessKey) or \
+                       getpass._raw_input('Amazon secret access key (will be saved in keychain): ').strip()
+
+        # Try to fetch the buckets with the given credentials
+        connection = boto.connect_s3(awsAccessKey.strip(), awsSecretKey.strip())
+
+        logging.debug('Start get_all_buckets')
+        # Exit if the information was not correct
+        try:
+            buckets = connection.get_all_buckets()
+        except:
+            logging.info('Invalid login credentials, please try again...')
+            return
+        logging.debug('end get_all_buckets')
+
+        # If it was correct, save it for the future
+        self.config.set('aws-access-key', awsAccessKey)
+        self.config.write()
+
+        setpassword('aws', awsAccessKey, awsSecretKey)
+
+        awsBucketName = self.config.get('aws-bucket-name') or \
+                        raw_input('S3 bucket name (www.yoursite.com): ').strip().lower()
+
+        if awsBucketName not in [b.name for b in buckets]:
+            if raw_input('Bucket does not exist, create it? (y/n): ') == 'y':
+
+                logging.debug('Start create_bucket')
+                try:
+                    awsBucket = connection.create_bucket(awsBucketName, policy='public-read')
+                except boto.exception.S3CreateError, e:
+                    logging.info(
+                        'Bucket with name %s already is used by someone else, please try again with another name' % awsBucketName)
+                    return
+                logging.debug('end create_bucket')
+
+                # Configure S3 to use the index.html and error.html files for indexes and 404/500s.
+                awsBucket.configure_website('index.html', 'error.html')
+
+                self.config.set('aws-bucket-website', awsBucket.get_website_endpoint())
+                self.config.set('aws-bucket-name', awsBucketName)
+                self.config.write()
+
+                logging.info('Bucket %s was selected with website endpoint %s' % (
+                self.config.get('aws-bucket-name'), self.config.get('aws-bucket-website')))
+                logging.info(
+                    'You can learn more about s3 (like pointing to your own domain) here: https://github.com/koenbok/Cactus')
 
 
-	def loadPlugins(self, force=False):
-		"""
-		Load plugins from the plugins directory and import the code.
-		"""
-		
-		plugins = []
-		
-		# Figure out the files that can possibly be plugins
-		for pluginPath in fileList(self.paths['plugins']):
-	
-			if not pluginPath.endswith('.py'):
-				continue
+            else:
+                return
+        else:
 
-			if 'disabled' in pluginPath:
-				continue
-			
-			pluginHandle = os.path.splitext(os.path.basename(pluginPath))[0]
-			
-			# Try to load the code from a plugin
-			try:
-				plugin = imp.load_source('plugin_%s' % pluginHandle, pluginPath)
-			except Exception, e:
-				logging.info('Error: Could not load plugin at path %s\n%s' % (pluginPath, e))
-				sys.exit()
-			
-			# Set an id based on the file name
-			plugin.id = pluginHandle
-			
-			plugins.append(plugin)
-		
-		# Sort the plugins by their defined order (optional)
-		def getOrder(plugin):
-			if hasattr(plugin, 'ORDER'):
-				return plugin.ORDER
-			return -1
-		
-		self._plugins = sorted(plugins, key=getOrder)
-	
-	def pluginMethod(self, method, *args, **kwargs):
-		"""
-		Run this method on all plugins
-		"""
-		
-		if not hasattr(self, '_plugins'):
-			self.loadPlugins()
-		
-		for plugin in self._plugins:
-			if hasattr(plugin, method):
-				getattr(plugin, method)(*args, **kwargs)
+            # Grab a reference to the existing bucket
+            for b in buckets:
+                if b.name == awsBucketName:
+                    awsBucket = b
+
+        self.config.set('aws-bucket-website', awsBucket.get_website_endpoint())
+        self.config.set('aws-bucket-name', awsBucketName)
+        self.config.write()
+
+        logging.info('Uploading site to bucket %s' % awsBucketName)
+
+        # Upload all files concurrently in a thread pool
+        totalFiles = multiMap(lambda p: p.upload(awsBucket), self.files())
+        changedFiles = [r for r in totalFiles if r['changed'] == True]
+
+        self.pluginMethod('postDeploy', self)
+
+        # Display done message and some statistics
+        logging.info('\nDone\n')
+
+        logging.info('%s total files with a size of %s' % \
+                     (len(totalFiles), fileSize(sum([r['size'] for r in totalFiles]))))
+        logging.info('%s changed files with a size of %s' % \
+                     (len(changedFiles), fileSize(sum([r['size'] for r in changedFiles]))))
+
+        logging.info('\nhttp://%s\n' % self.config.get('aws-bucket-website'))
+
+
+    def files(self):
+        """
+        List of build files.
+        """
+
+        paths = fileList(self.paths['build'], relative=True)
+        paths = filterPaths(paths, self.ignorePatterns())
+
+        return [File(self, p) for p in paths]
+
+
+    def loadPlugins(self, force=False):
+        """
+        Load plugins from the plugins directory and import the code.
+        """
+
+        plugins = []
+
+        # Figure out the files that can possibly be plugins
+        for pluginPath in fileList(self.paths['plugins']):
+
+            if not pluginPath.endswith('.py'):
+                continue
+
+            if 'disabled' in pluginPath:
+                continue
+
+            pluginHandle = os.path.splitext(os.path.basename(pluginPath))[0]
+
+            # Try to load the code from a plugin
+            try:
+                plugin = imp.load_source('plugin_%s' % pluginHandle, pluginPath)
+            except Exception, e:
+                logging.info('Error: Could not load plugin at path %s\n%s' % (pluginPath, e))
+                sys.exit()
+
+            # Set an id based on the file name
+            plugin.id = pluginHandle
+
+            plugins.append(plugin)
+
+        # Sort the plugins by their defined order (optional)
+        def getOrder(plugin):
+            if hasattr(plugin, 'ORDER'):
+                return plugin.ORDER
+            return -1
+
+        self._plugins = sorted(plugins, key=getOrder)
+
+    def pluginMethod(self, method, *args, **kwargs):
+        """
+        Run this method on all plugins
+        """
+
+        if not hasattr(self, '_plugins'):
+            self.loadPlugins()
+
+        for plugin in self._plugins:
+            if hasattr(plugin, method):
+                getattr(plugin, method)(*args, **kwargs)

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -173,9 +173,13 @@ class Site(object):
                 dirs.remove('.svn')
             if '.DS_Store' in files:
                 files.remove('.DS_Store')
+            if '.gitignore' in files:
+                files.remove('.gitignore')
             dest_path = path.replace(self.paths['static'], staticBuildPath)
             for file in files:
-                shutil.copy(os.path.join(path, file), os.path.join(dest_path, file))
+                if not os.path.exists(os.path.join(dest_path)):
+                    os.makedirs(os.path.join(dest_path))
+                shutil.copyfile(os.path.join(path, file), os.path.join(dest_path, file))
 
 
         # If there is a folder, replace it with a copy

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -38,6 +38,7 @@ class Site(object):
 			'templates': os.path.join(path, 'templates'),
 			'plugins': os.path.join(path, 'plugins'),
 			'static': os.path.join(path, 'static'),
+            'locales': os.path.join(path, 'conf', 'locale'),
 			'script': os.path.join(os.getcwd(), __file__)
 		}
 		
@@ -52,7 +53,8 @@ class Site(object):
 			from django.conf import settings
 			settings.configure(
 				TEMPLATE_DIRS=[self.paths['templates'], self.paths['pages']],
-				INSTALLED_APPS=['django.contrib.markup']
+				INSTALLED_APPS=['django.contrib.markup'],
+                LOCALE_PATHS=[self.paths['locales'],],
 			)
 		except:
 			pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.5
+Django==1.4.5
 Markdown==2.2.1
 boto==2.8.0


### PR DESCRIPTION
This will allow you to internationalize your static site easily and create separate sites for each language under .build/en etc.

First you need to wrap your string in {% trans %} tags so you can create po files.  The[i18n lint tool](https://github.com/rory/django-template-i18n-lint)  will help automate this just run
```bash
cactus i18nlint -r
```

Next you need to create po files just run the following for each langauge.  See [Django docs for makemessages](https://docs.djangoproject.com/en/dev/ref/django-admin/#django-admin-makemessages)
```bas
django-admin.py makemessages -l en
```

Then send your po files to your translators when you get them back run
```bash
django-admin.py compilemessages
```

After that you can run cactus build or serve and it will create subdirectories for each language code.