### PR TITLE
v3: GCS metadata acl key should be within a list

### DIFF
--- a/cactus/deployment/gcs/file.py
+++ b/cactus/deployment/gcs/file.py
@@ -16,7 +16,7 @@ class GCSFile(BaseFile):
         Note: we don't set the etag, since the GCS API does not accept what we set
         """
         metadata = {
-            "acl": {"entity": "allUsers", "role": "READER",},
+            "acl": [{"entity": "allUsers", "role": "READER"},],
             "md5Hash": base64.b64encode(self.payload_checksum.decode('hex')),
             "contentType": self.content_type,  # Given twice...
             "cacheControl": unicode(self.cache_control)  # That's what GCS will return


### PR DESCRIPTION
While testing GCS within v3, the file permissions were not set to public on deployment. After comparing the metadata to the documentation, the `acl` key should be a list of permissions according to the docs (https://developers.google.com/resources/api-libraries/documentation/storage/v1beta2/python/latest/storage_v1beta2.objects.html#insert). With this change permissions are set successfully on deployment. 
