### PR TITLE
First pass at Markdown-only blog posts

### DIFF
--- a/cactus/page.py
+++ b/cactus/page.py
@@ -46,6 +46,9 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
     def is_html(self):
         return urlparse.urlparse(self.source_path).path.endswith('.html')
 
+    def is_markdown(self):
+        return urlparse.urlparse(self.source_path).path.endswith('.md')
+
     def is_index(self):
         return urlparse.urlparse(self.source_path).path.endswith('index.html')
 
@@ -135,7 +138,7 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
         will be converted in a dict: {'name': 'koen', 'age': '29'}
         """
 
-        if not self.is_html():
+        if not self.is_html() and not self.is_markdown():
             return {}, data
 
         values = {}

--- a/cactus/skeleton/plugins/blog.disabled.py
+++ b/cactus/skeleton/plugins/blog.disabled.py
@@ -3,85 +3,136 @@ import datetime
 import logging
 
 ORDER = 999
-POSTS_PATH = 'posts/'
+DEFAULT_PATH = 'posts/'
 POSTS = []
 
 from django.template import Context
 from django.template.loader import get_template
 from django.template.loader_tags import BlockNode, ExtendsNode
 
-def getNode(template, context=Context(), name='subject'):
-	"""
-	Get django block contents from a template.
-	http://stackoverflow.com/questions/2687173/
-	django-how-can-i-get-a-block-from-a-template
-	"""
-	for node in template:
-		if isinstance(node, BlockNode) and node.name == name:
-			return node.render(context)
-		elif isinstance(node, ExtendsNode):
-			return getNode(node.nodelist, context, name)
-	raise Exception("Node '%s' could not be found in template." % name)
+def get_post_meta(name, page, warn=True):
+    """
+    Given a string 'name', try to find a matching value either in the page
+    context or in config.json under blog['defaults']
+    """
+    context = page.context()
+    defaults = page.site.config.get('blog', {}).get('defaults')
 
+    if name in context:
+        return context.get(name, '')
+    elif name in defaults:
+        return defaults.get(name, '')
+    else:
+        if warn:
+            logging.warning("%s - No %s found" % (page.path, name))
+        return ''
+
+def get_post_date(page):
+    """
+    Look for a date in the page context, otherwise use the file modification
+    date.
+
+    Accepts dd-mm-yyyy or yyyy-mm-dd
+    """
+    manual_date = get_post_meta('date', page, False)
+    bad_date = False
+
+    if manual_date:
+        for format in ['%Y-%m-%d', '%d-%m-%Y']:
+            try:
+                return datetime.datetime.strptime(manual_date, format)
+            except:
+                bad_date = True
+                continue
+    
+        if bad_date:
+            logging.warning("%s - Date isn't YYYY-MM-DD or DD-MM-YYYY" % (page.path))
+
+    mod_time = os.path.getmtime(page.full_source_path)
+    return datetime.datetime.fromtimestamp(mod_time)
+
+def get_post_output_path(path):
+    """
+    Return a .html path for build/link purposes
+    """
+    return path.replace('.md', '.html')
 
 def preBuild(site):
+    """
+    Find and parse all .md files in the posts_path directory, add them to POSTS
+    """
+    global POSTS
 
-	global POSTS
+    posts_path = site.config.get('blog', {}).get('path', DEFAULT_PATH)
 
-	# Build all the posts
-	for page in site.pages():
-		if page.path.startswith(POSTS_PATH):
+    # Build all the posts
+    for page in site.pages():
+        if page.path.startswith(posts_path):
 
-			# Skip non html posts for obious reasons
-			if not page.path.endswith('.html'):
-				continue
+            # Skip non md posts for obvious reasons
+            if not page.path.endswith('.md'):
+                continue
 
-			# Find a specific defined variable in the page context,
-			# and throw a warning if we're missing it.
-			def find(name):
-				c = page.context()
-				if not name in c:
-					logging.info("Missing info '%s' for post %s" % (name, page.path))
-					return ''
-				return c.get(name, '')
+            # Skip posts with 'status: draft' in the context
+            if get_post_meta('status', page, False) == 'draft':
+                continue
 
-			# Build a context for each post
-			postContext = {}
-			postContext['title'] = find('title')
-			postContext['author'] = find('author')
-			postContext['date'] = find('date')
-			postContext['path'] = page.path
-			postContext['body'] = getNode(get_template(page.path), name="body")
+            # Workaround to actually get a hold of the context-stripped
+            # data returned by page.parse_context()
+            context, clean_data = page.parse_context(page.data())
 
-			# Parse the date into a date object
-			try:
-				postContext['date'] = datetime.datetime.strptime(postContext['date'], '%d-%m-%Y')
-			except Exception, e:
-				logging.warning("Date format not correct for page %s, should be dd-mm-yy\n%s" % (page.path, e))
-				continue
+            # Build a context for each post
+            post_context = {}
+            post_context['title'] = get_post_meta('title', page)
+            post_context['author'] = get_post_meta('author', page)
+            post_context['date'] = get_post_date(page)
+            post_context['path'] = get_post_output_path(page.path)
+            post_context['body'] = clean_data
+            post_context['template'] = get_post_meta('template', page)
 
-			POSTS.append(postContext)
+            POSTS.append(post_context)
 
-	# Sort the posts by date
-	POSTS = sorted(POSTS, key=lambda x: x['date'])
-	POSTS.reverse()
+            # Override build path so we output an .html page
+            page.build_path = get_post_output_path(page.path)
 
-	indexes = xrange(0, len(POSTS))
+    # Sort the posts by date
+    POSTS = sorted(POSTS, key=lambda x: x['date'])
+    POSTS.reverse()
 
-	for i in indexes:
-		if i+1 in indexes: POSTS[i]['prevPost'] = POSTS[i+1]
-		if i-1 in indexes: POSTS[i]['nextPost'] = POSTS[i-1]
+    indexes = xrange(0, len(POSTS))
+
+    for i in indexes:
+        if i+1 in indexes: POSTS[i]['prev_post'] = POSTS[i+1]
+        if i-1 in indexes: POSTS[i]['next_post'] = POSTS[i-1]
 
 
-def preBuildPage(site, page, context, data):
-	"""
-	Add the list of posts to every page context so we can
-	access them from wherever on the site.
-	"""
-	context['posts'] = POSTS
+def preBuildPage(page, context, data):
+    """
+    Add the list of posts to every page context so we can
+    access them from wherever on the site.
 
-	for post in POSTS:
-		if post['path'] == page.path:
-			context.update(post)
+    For posts, inject the post's template
+    """
+    context['posts'] = POSTS
+    posts_path = page.site.config.get('blog', {}).get('path', DEFAULT_PATH)
 
-	return context, data
+    # If we're building a post, loop through POSTS to find the current one
+    if page.path.startswith(posts_path):
+        for post in POSTS:
+            if post['path'] == get_post_output_path(page.path):
+
+                # Add the current post to the page's context as 'post'
+                context.update(post)
+
+                # Get the full path to the post's template
+                full_template_path = ''.join([page.site.template_path, '/',
+                                             post['template']])
+
+                # Load and inject the template contents into the page we're building
+                with open(full_template_path, 'rU') as f:
+                    try:
+                        data = f.read().decode('utf-8')
+                    except:
+                        logging.warning("%s - Could not process template", post.path)
+
+    return context, data


### PR DESCRIPTION
Updates the blog plugin to be more configurable and work with pure(ish) Markdown files. See also #15.

I discussed this via email with Koen a few months ago, but I haven't heard back in a while. Figured I'd go ahead and submit it and see what happens. I don't necessarily expect this to get merged right now, just want to put it out there for discussion and improvement. Here's my last email to Koen:

---

You can see I had to make a couple of tiny changes to page.py. There are other ways around that problem but that was the least intrusive I could think of. If you'd rather solve it in a different way, let me know and I can adapt the blog plugin accordingly.

Here's a writeup of how it works right now: [https://gist.github.com/cz/5f8e58e76dfa9d0f8e3e]. Could be the basis for user docs later on.

Feel free to comment inline on the commit if there are changes you'd like to see. Or if this looks good enough for a pull request just let me know and I'll submit it.

Finally, was curious to know what your vision is for the plugin system in general. Is it as extensive as you'd like it to be? Do you imagine any sort of ecosystem of externally-maintained plugins? I'm inclined to continue tinkering with this (exploring stuff like tags and excerpts) to see if we can arrive at a proper Jekyll/Pelican alternative.
