### PR TITLE
Remove css location fix in JS

### DIFF
--- a/cactus/skeleton/pages/error.html
+++ b/cactus/skeleton/pages/error.html
@@ -15,12 +15,6 @@
 
       // Add the missing url to the text
       $("#url").text(window.location.pathname);
-
-      // Fix the css locations dynamically
-      $("head link").each(function() {
-        for (var i=0; i<window.location.pathname.split(/\//g).length-2; i++)
-          $(this).attr("href", "../" + $(this).attr("href"));
-      });
     })
   </script>
 {% endblock %}


### PR DESCRIPTION
With the new usage of {% static '/static/css/XYZ.css' %} this fix not needed anymore.
