### PR TITLE
Using django-markwhat as a drop-in replacement for ``django.contirb.markup``

### DIFF
--- a/cactus/site.py
+++ b/cactus/site.py
@@ -52,7 +52,7 @@ class Site(object):
 			from django.conf import settings
 			settings.configure(
 				TEMPLATE_DIRS=[self.paths['templates'], self.paths['pages']],
-				INSTALLED_APPS=['django.contrib.markup']
+				INSTALLED_APPS=['django_markwhat']
 			)
 		except:
 			pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.5
 Markdown==2.2.1
 boto==2.8.0
+django-markwhat==2014.9.20


### PR DESCRIPTION
This patch fixes #102

Using django-markwhat as a drop-in replacement
for ``django.contirb.markup`` since it's deprecated.

**From django-markwhat docs**

Extracted from [Django 1.4 since markup deprecation](https://docs.djangoproject.com/en/dev/releases/1.5/#django-contrib-markup)

**Supported Python versions**

* Python 2 (2.7)
* Python 3 (3.2, 3.3, 3.4)
* PyPy