### PR TITLE
Build the list of pages only once

### DIFF
--- a/cactus/site.py
+++ b/cactus/site.py
@@ -340,24 +340,19 @@ class Site(SiteCompatibilityLayer):
     def pages(self):
         """
         List of pages.
+        This routine is called from different places,
+        but builds the page list only once
         """
-
         if not hasattr(self, "_page_cache"):
             self._page_cache = {}
 
-        pages = []
-
-        for path in fileList(self.page_path, relative=True):
-            
-            if path.endswith("~"):
-                continue
-
-            if not self._page_cache.has_key(path):
+            for path in fileList(self.page_path, relative=True):
+                # ignore backup files
+                if path.endswith("~"):
+                    continue
                 self._page_cache[path] = Page(self, path)
 
-            pages.append(self._page_cache[path])
-
-        return pages
+        return self._page_cache.values()
 
     def _rebuild_should_ignore(self, file_path):
         


### PR DESCRIPTION
`Site.pages()` reads the list of pages every time it is called. I don't think, that it's meant to be like that.