### PR TITLE
Page context

### DIFF
--- a/cactus/page.py
+++ b/cactus/page.py
@@ -65,11 +65,17 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
         return os.path.join(self.site.build_path, self.build_path)
 
     def data(self):
+        if not hasattr(self, "_data"):
+            self._read_data()
+        return self._data
+
+    def _read_data(self):
         with open(self.full_source_path, 'rU') as f:
             try:
-                return f.read().decode('utf-8')
+                self._data = f.read().decode('utf-8')
             except:
-                logger.warning("Template engine could not process page: %s", self.path)
+                logger.warning("Page file could not be read: %s", self.path)
+                self._data = ''
 
     def context(self, data=None, extra=None):
         """

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -82,13 +82,10 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
         """
         The page context.
         """
-        if extra is None:
-            extra = {}
-
         context = {'__CACTUS_CURRENT_PAGE__': self,}
 
         context.update(self.site.context())
-        context.update(extra)
+        context.update(extra or {})
         context.update(self.parse_context())
 
         return Context(context)
@@ -155,8 +152,8 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
                 continue
 
             elif splitChar in line:
-                line = line.split(splitChar)
-                values[line[0].strip()] = (splitChar.join(line[1:])).strip()
+                key, value = line.split(splitChar, 1)
+                values[key.strip()] = value.strip()
 
             else:
                 break

--- a/cactus/page.py
+++ b/cactus/page.py
@@ -147,16 +147,16 @@ class Page(PageCompatibilityLayer, ResourceURLHelperMixin):
             return {}
 
         for i, line in enumerate(lines):
-
-            if not line:
-                continue
-
-            elif splitChar in line:
-                key, value = line.split(splitChar, 1)
-                values[key.strip()] = value.strip()
-
-            else:
+            # Context lines start at the top of the file.
+            # The text start after the first empty line
+            # or at the first line without a colon
+            if not splitChar in line:
+                if not line:
+                    i += 1
                 break
+
+            key, value = line.split(splitChar, 1)
+            values[key.strip()] = value.strip()
 
         self._data = '\n'.join(lines[i:])
         self._page_context = values

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -267,6 +267,10 @@ class Site(SiteCompatibilityLayer):
                 else:
                     os.remove(path)
 
+        # One test / use case depends on
+        # the pages being read from disk for every built
+        self._build_page_list()
+
         # Render the pages to their output files
         mapper = map
         if self._parallel >= PARALLEL_AGGRESSIVE:
@@ -342,12 +346,12 @@ class Site(SiteCompatibilityLayer):
         List of pages.
         """
         if not hasattr(self, "_pages"):
-            self._read_pages()
+            self._build_page_list()
         return self._pages
 
-    def _read_pages(self):
+    def _build_page_list(self):
         """
-        Read the pages from disk
+        Build the page list from the files found on disk
         """
         self._pages = [
             Page(self, path)

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -341,23 +341,18 @@ class Site(SiteCompatibilityLayer):
         """
         List of pages.
         """
+        if not hasattr(self, "_pages"):
+            self._read_pages()
+        return self._pages
 
-        if not hasattr(self, "_page_cache"):
-            self._page_cache = {}
-
-        pages = []
-
-        for path in fileList(self.page_path, relative=True):
-            
-            if path.endswith("~"):
-                continue
-
-            if not self._page_cache.has_key(path):
-                self._page_cache[path] = Page(self, path)
-
-            pages.append(self._page_cache[path])
-
-        return pages
+    def _read_pages(self):
+        """
+        Read the pages from disk
+        """
+        self._pages = [
+            Page(self, path)
+            for path in fileList(self.page_path, relative=True)
+            if not path.endswith("~")]
 
     def _rebuild_should_ignore(self, file_path):
         

--- a/cactus/tests/data/colon-in-first-line.html
+++ b/cactus/tests/data/colon-in-first-line.html
@@ -1,0 +1,6 @@
+Author: Me
+Title: Big Thing
+
+Let's have one thing very clear: whatever.
+
+Next Paragraph

--- a/cactus/tests/test_basic.py
+++ b/cactus/tests/test_basic.py
@@ -5,6 +5,7 @@ import shutil
 from cactus.tests import SiteTestCase
 from cactus.utils.filesystem import fileList
 from cactus.utils.url import path_to_url
+from cactus.page import Page
 
 
 class TestSite(SiteTestCase):
@@ -48,7 +49,7 @@ class TestSite(SiteTestCase):
 
     def testPageContext(self):
         """
-        Test that page context is parsed and uses in the pages.
+        Test that page context is parsed and used in the pages.
         """
 
         shutil.copy(
@@ -114,3 +115,29 @@ class TestSite(SiteTestCase):
 
         with open(os.path.join(self.path, '.build', other), 'rU') as f:
             self.assertEqual('False', f.read())
+
+
+class TestPage(SiteTestCase):
+
+    def testPageContext(self):
+        """
+        Test parsing of page context is parsed and used in the pages.
+        """
+
+        shutil.copy(
+            os.path.join('cactus', 'tests', 'data', "koenpage-in.html"),
+            os.path.join(self.path, 'pages', 'koenpage.html')
+        )
+        page = Page(self.site, 'koenpage.html')
+        self.assertEqual(page.parse_context(),
+                         {'name': 'Koen Bok', 'age': '29'})
+
+        shutil.copy(
+            os.path.join('cactus', 'tests', 'data', 'colon-in-first-line.html'),
+            os.path.join(self.path, 'pages', 'test.html')
+        )
+        page = Page(self.site, 'test.html')
+        self.assertEqual(page.parse_context(),
+                         {u'Author': u'Me', u'Title': u'Big Thing'})
+        self.assertEqual(page._data,
+            "Let's have one thing very clear: whatever.\n\nNext Paragraph")


### PR DESCRIPTION
This changes the behavior of `Site` and `Page` in several subtle aspects.

- `Site` builds the list of pages only when `Site._build_page_list` is called and not whenever `Site.pages()` is accessed.
- `Page` reads the page file only once and not whenever `Page.data()` is accessed.
- The content of the page is made a property of `Page` and is no more passed around as an argument.
- `Page.parse_context` is changed to work more like I expected: The context data starts at the top of the file and the content starts after the first blank line or with the first line, that doesn't contain a colon.