### PR TITLE
Page context plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ Cactus makes it easy to relatively link to pages and static assets inside your p
 
 Just use the URL you would normally use: don't forget the leading slash.
 
+You can add extra context to your pages. Just insert it on the top of the file like this:
+
+    name: koen
+    age: 29
+    {% extends "base.html" %}
+    …
+
+which will be converted to a dict: `{'name': 'koen', 'age': '29'}` and added to the context. 
+If the first line of your document should contain a colon, 
+you can use the more explicit style of metadata [as used in Jekyll](http://jekyllrb.com/docs/frontmatter/):
+
+    ---
+    Author: Me
+    Style:  Great
+    ---
+    Todays motto: whatever
+
+Always use `---` (three dashes) to fence the metadata.
 
 ### Templates
 

--- a/cactus/plugin/builtin/pagecontext.py
+++ b/cactus/plugin/builtin/pagecontext.py
@@ -1,0 +1,120 @@
+#coding:utf-8
+import logging
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+class PageContextPlugin(object):
+    """
+    A plugin to extract context variables from the top of the file
+
+    TODO:
+    - read style of metadata from config
+    - read splitChar from config
+    """
+
+    def preBuildPage(self, page, context, data):
+        """
+        Update the page context with the context variables from the file
+        and delete them
+        """
+        if not page.is_html() or not data:
+            return context, data
+
+        lines = data.splitlines()
+
+        # Look into the file to decide on the style of metadata
+        # TODO: make that configurable
+        if lines[0].strip() == u'---':
+            page_context, lines = self.jekyll_style(lines)
+        else:
+            page_context, lines = self.simple_style(lines)
+        context.update(page_context)
+
+        return context, '\n'.join(lines)
+
+    def jekyll_style(self, lines):
+        if not lines or lines[0].strip() != u'---':  # no metadata
+            return {}, lines
+
+        context = {}
+        splitChar = ':'
+        for i, line in enumerate(lines[1:]):
+            if line.strip() == u'---':  # end of metadata
+                i += 1
+                break
+
+            try:
+                key, value = line.split(splitChar, 1)
+            except ValueError:
+                # splitChar not in line
+                logger.warning('Page context data seem to end in line %d', i)
+                break
+
+            context[key.strip()] = value.strip()
+
+        return context, lines[i+1:]
+
+    def simple_style(self, lines):
+        """
+        Only lines at the top of the file with a colon are metadata.
+        No multiline metadata
+        """
+        context = {}
+        splitChar = ':'
+
+        for i, line in enumerate(lines):
+
+            if splitChar not in line:
+                break
+
+            key, value = line.split(splitChar, 1)
+            context[key.strip()] = value.strip()
+
+        return context, lines[i:]
+
+    def multimarkdown_style(self, lines):
+        """
+        metadata as defined in http://fletcher.github.io/MultiMarkdown-4/metadata
+        """
+        context = {}
+        splitChar = ':'
+        fenced = False
+        key = None
+
+        if splitChar not in lines[0] and lines[0].strip() != u'---':
+            return {}, lines  # no metadata
+
+        for i, line in enumerate(lines):
+            # fencing is allowed but not required in multimarkdown
+            if line.strip() == u'---':
+                if i == 0:
+                    fenced = True
+                    continue
+                elif fenced:
+                    i += 1
+                    break
+
+            # a blank line triggers the beginning of the rest of the document
+            if not line.strip():
+                # if the file starts with a blank line, nothing should be changed
+                if i != 0:
+                    i += 1
+                break
+
+            # indented lines are the continuation of the previous value
+            # but multiline values don't have to be indented
+            if key and (re.match(r'\s', line) or not splitChar in line):
+                context[key] = ' '.join(
+                    (context[key], line.lstrip()))
+                continue
+
+            key, value = line.split(splitChar, 1)
+
+            # keys are lower cased and stripped of all whitespace
+            key = re.sub(r'\s', '', key.lower())
+            context[key] = value.strip()
+
+        return context, lines[i:]

--- a/cactus/site.py
+++ b/cactus/site.py
@@ -16,6 +16,7 @@ from cactus.i18n.commands import MessageMaker, MessageCompiler
 from cactus.plugin.builtin.cache import CacheDurationPlugin
 from cactus.plugin.builtin.context import ContextPlugin
 from cactus.plugin.builtin.ignore import IgnorePatternsPlugin
+from cactus.plugin.builtin.pagecontext import PageContextPlugin
 from cactus.plugin.loader import CustomPluginsLoader, ObjectsPluginLoader
 from cactus.plugin.manager import PluginManager
 from cactus.static.external.manager import ExternalManager
@@ -75,8 +76,11 @@ class Site(SiteCompatibilityLayer):
             [
                 CustomPluginsLoader(self.plugin_path),  # User plugins
                 ObjectsPluginLoader([   # Builtin plugins
-                    ContextPlugin(), CacheDurationPlugin(),
-                    IgnorePatternsPlugin(), PageContextCompatibilityPlugin(),
+                    ContextPlugin(),
+                    PageContextPlugin(),
+                    CacheDurationPlugin(),
+                    IgnorePatternsPlugin(),
+                    PageContextCompatibilityPlugin(),
                 ])
             ]
         )

--- a/cactus/tests/test_context.py
+++ b/cactus/tests/test_context.py
@@ -46,21 +46,61 @@ class TestCustomPageContext(SiteTestCase):
 
     Includes the built-in site context ('CACTUS'), and custom context.
     """
-    def setUp(self):
-        super(TestCustomPageContext, self).setUp()
-
-        page = "a: 1\n\tb: Monkey\n{{ a }}\n{{ b }}"
-        with open(os.path.join(self.site.page_path, "test.html"), "w") as f:
-            f.write(page)
-
-        self.site.build()
 
     def test_custom_context(self):
         """
         Test that custom context is provided
         """
-        with open(os.path.join(self.site.build_path, "test.html")) as f:
-            a, b = f.read().split("\n")
+        test_data = [
+            ("a: 1\n"
+             "\tb: Monkey\n"
+             "{{ a }}\n"
+             "{{ b }}",
 
-        self.assertEqual(a, "1")
-        self.assertEqual(b, "Monkey")
+             "1\n"
+             "Monkey"),
+
+            ("a: 1\n"
+             "\n"      # blank line inserted
+             "\tb: Monkey\n"
+             "{{ a }}",
+
+             "\n"
+             "\tb: Monkey\n"
+             "1"),
+
+            ("---\n"    # fenced
+             " a: 1\n"
+             "b: Monkey\n"
+             "---\n"
+             "{{ a }}\n"
+             "{{ b }}",
+
+             "1\n"
+             "Monkey"),
+
+            ("---\n"    # double fenced
+             " a: 1\n"
+             "b: Monkey\n"
+             "---\n"
+             "---\n"
+             "c: 1\n"
+             "---\n"
+             "{{ a }}\n"
+             "{{ b }}",
+
+             "---\n"
+             "c: 1\n"
+             "---\n"
+             "1\n"
+             "Monkey"),
+
+        ]
+        for page, expected in test_data:
+            with open(os.path.join(self.site.page_path, "test.html"), "w") as f:
+                f.write(page)
+
+            self.site.build()
+
+            with open(os.path.join(self.site.build_path, "test.html")) as f:
+                self.assertEqual(f.read(), expected)

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     },
     zip_safe=False,
     setup_requires=['nose'],
-    tests_require=['nose', 'mock', 'tox', 'unittest2'],
+    tests_require=['nose', 'mock', 'tox', 'unittest2', 'testfixtures'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
Ripped parsing of page context out of `Page` and put it into a plugin. With tests and documentation.
There are different styles of metadata, the plugin tries to guess what is appropriate.
Multimarkdown style is implemented but not used. In the future the style should be up for configuration.