### PR TITLE
Update Google Storage API endpoint

### DIFF
--- a/cactus/deployment/gcs/engine.py
+++ b/cactus/deployment/gcs/engine.py
@@ -38,7 +38,7 @@ class GCSDeploymentEngine(BaseDeploymentEngine):
             credentials = self.credentials_manager.get_credentials()
             http_client = self._HTTPClass()
             credentials.authorize(http_client)
-            service = apiclient.discovery.build('storage', 'v1beta2', http=http_client)
+            service = apiclient.discovery.build('storage', 'v1', http=http_client)
             self._service_pool[ident] = service
 
         return service


### PR DESCRIPTION
`JSON API v1beta2` is no longer available. Changing this to `v1` makes it work again.
More information here: https://cloud.google.com/storage/docs/json_api/v1/how-tos/migrate