### PR TITLE
add .gitignore to project skeleton

### DIFF
--- a/cactus/skeleton/.gitignore
+++ b/cactus/skeleton/.gitignore
@@ -1,0 +1,5 @@
+.build
+.deploy
+*.pyc
+*.disabled.py
+


### PR DESCRIPTION
I think that this would be handy when creating new projects (especially for new users, who might not know yet what *.disabled.py files are).

I would leave the decision of how to handle the static/ directory to the user.