### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md
+include LICENSE README.md


### PR DESCRIPTION
Include the LICENSE file in the source distribution (sdist) so that downstream packagers and porters (eg: FreeBSD Ports) can include the license file in their packages