### PR TITLE
Django 1.6

### DIFF
--- a/cactus/site.py
+++ b/cactus/site.py
@@ -140,7 +140,7 @@ class Site(SiteCompatibilityLayer):
 
         settings = {
             "TEMPLATE_DIRS": [self.template_path, self.page_path],
-            "INSTALLED_APPS": ['django.contrib.markup'],
+            "INSTALLED_APPS": ['django_markwhat'],
         }
 
         if self.locale is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.5.5
+Django>=1.6,<1.7
 django-markwhat>=1.4,<2
 markdown2
 argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.5.5
+django-markwhat>=1.4,<2
 markdown2
 argparse
 keyring


### PR DESCRIPTION
Update to Django 1.6, and use `django-markwhat` to account for `django.contrib.markup` removal (see #106).