### PR TITLE
Fix: `cactus serve` fails with 'str' object has not attribute 'decode'

### DIFF
--- a/cactus/server.py
+++ b/cactus/server.py
@@ -82,7 +82,7 @@ class WebServer(object):
 
     def __init__(self, path, port=8080):
 
-        self.path = path.decode("utf-8")
+        self.path = path.decode("utf-8") if hasattr(path, 'decode') else path
         self.port = port
 
         # print type(self.path)


### PR DESCRIPTION
On win7 with py34 `cactus serve` fails with a loud: 'str' object has not attribute 'decode'.
Not sure if this is a regression as I saw some earlier commits that removed the .decode call. This fix will only try to decode if the path object has a decode method, so it should not introduce any new problems :).