### PR TITLE
Change get_bucket to load only required bucket

### DIFF
--- a/cactus/deployment/s3/engine.py
+++ b/cactus/deployment/s3/engine.py
@@ -65,8 +65,8 @@ class S3DeploymentEngine(BaseDeploymentEngine):
         :returns: The Bucket if found, None otherwise.
         :raises: InvalidCredentials if we can't connect to AWS
         """
-        s3 = self.get_connection()
-        return s3.get_bucket(self.bucket_name)
+        s3con = self.get_connection()
+        return s3con.get_bucket(self.bucket_name)
 
     def create_bucket(self):
         """

--- a/cactus/deployment/s3/engine.py
+++ b/cactus/deployment/s3/engine.py
@@ -65,9 +65,8 @@ class S3DeploymentEngine(BaseDeploymentEngine):
         :returns: The Bucket if found, None otherwise.
         :raises: InvalidCredentials if we can't connect to AWS
         """
-        buckets = self._get_buckets()
-        buckets = dict((bucket.name, bucket) for bucket in buckets)
-        return buckets.get(self.bucket_name)
+        s3 = self.get_connection()
+        return s3.get_bucket(self.bucket_name)
 
     def create_bucket(self):
         """


### PR DESCRIPTION
As of now get_bucket() calls _get_buckets(). This tries to get all the buckets for the API KEY. The problem with this is that for example in my case I provide clients with IAM keys that can only access their particular bucket, not all the buckets in my company's account. The method fails because it tries to list all buckets and it does not have permission.

There is no reason for get_bucket to try to get all the buckets in the account.

I've made changes so that it fetches only the bucket supplied by conf.json.