### PR TITLE
Improve Python3 compatibility; update Django to 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.venv/**
+.idea/**
 *.pyc
 dist
 build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-.venv/**
+.venv*
 .idea/**
 *.pyc
 dist

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-[![Build Status](https://travis-ci.org/eudicots/Cactus.svg?branch=master)](https://travis-ci.org/eudicots/Cactus)
+Fork Info
+---------
 
-News
---------------
+This is a fork of Cactus 3. It extends the `{% url %}` template tag with language/i18n support by adding the language code to the root URL. This is by no means bullet proof - it may break certain website builds. It works for me, though.
+
+When I have time to straighten this up and document it properly, I'll send a pull request to the Cactus team - promise!
+
+
+
 
 ### Cactus 3 is out!
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-Fork Info
----------
-
-This is a fork of Cactus 3. It extends the `{% url %}` template tag with language/i18n support by adding the language code to the root URL. This is by no means bullet proof - it may break certain website builds. It works for me, though.
-
-When I have time to straighten this up and document it properly, I'll send a pull request to the Cactus team - promise!
-
-
-
 
 ### Cactus 3 is out!
 

--- a/cactus/deployment/__init__.py
+++ b/cactus/deployment/__init__.py
@@ -32,7 +32,8 @@ def get_deployment_engine_class(provider):
         _mod = __import__(module, fromlist=[engine])
     except ImportError as e:
         logger.error("Unable to import requested engine (%s) for provider %s", engine, provider)
-        logger.error("A required library was missing: %s", e.message)
+        logger.error("A required library was missing: %s", str(e))
         logger.error("Please install the library and try again")
+        raise e
     else:
         return getattr(_mod, engine)

--- a/cactus/i18n/commands.py
+++ b/cactus/i18n/commands.py
@@ -12,6 +12,9 @@ DEFAULT_COMMAND_KWARGS = {
     "pythonpath": None,
     "traceback": True,
     "all": False,
+    "no_color": False,
+    "exclude": [],
+    "fuzzy": False,
 }
 
 DEFAULT_MAKEMESSAGES_KWARGS = {

--- a/cactus/template_tags.py
+++ b/cactus/template_tags.py
@@ -2,14 +2,13 @@
 import os
 import logging
 
-from django.template.base import Library
-from django.conf import settings
+from django import template
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
 logger = logging.getLogger(__name__)
 
-register = Library()
+register = template.Library()
 
 
 def static(context, link_url):

--- a/cactus/utils/inspect23.py
+++ b/cactus/utils/inspect23.py
@@ -1,0 +1,89 @@
+"""
+Python2/3 compatible version of inspect.
+Source: https://github.com/timgraham/django/blob/3872a33132a4bb6aa22b237927597bbfdf6f21d7/django/utils/inspect.py
+
+Slightly modified so getargspec() always returns a named tuple (ArgSpec).
+"""
+
+from __future__ import absolute_import
+
+import inspect
+import six
+from collections import namedtuple
+
+ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+
+
+def getargspec(func):
+    if six.PY2:
+        return inspect.getargspec(func)
+
+    sig = inspect.signature(func)
+    args = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ]
+    varargs = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.VAR_POSITIONAL
+    ]
+    varargs = varargs[0] if varargs else None
+    varkw = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.VAR_KEYWORD
+    ]
+    varkw = varkw[0] if varkw else None
+    defaults = [
+        p.default for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and p.default is not p.empty
+    ] or None
+    return ArgSpec(args, varargs, varkw, defaults)
+
+
+def get_func_args(func):
+    if six.PY2:
+        argspec = inspect.getargspec(func)
+        return argspec.args[1:]  # ignore 'self'
+
+    sig = inspect.signature(func)
+    return [
+        arg_name for arg_name, param in sig.parameters.items()
+        if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ]
+
+
+def func_accepts_kwargs(func):
+    if six.PY2:
+        # Not all callables are inspectable with getargspec, so we'll
+        # try a couple different ways but in the end fall back on assuming
+        # it is -- we don't want to prevent registration of valid but weird
+        # callables.
+        try:
+            argspec = inspect.getargspec(func)
+        except TypeError:
+            try:
+                argspec = inspect.getargspec(func.__call__)
+            except (TypeError, AttributeError):
+                argspec = None
+        return not argspec or argspec[2] is not None
+
+    return any(
+        p for p in inspect.signature(func).parameters.values()
+        if p.kind == p.VAR_KEYWORD
+    )
+
+
+def func_has_no_args(func):
+    args = inspect.getargspec(func)[0] if six.PY2 else [
+        p for p in inspect.signature(func).parameters.values()
+        if p.kind == p.POSITIONAL_OR_KEYWORD and p.default is p.empty
+    ]
+    return len(args) == 1
+
+
+def func_supports_parameter(func, parameter):
+    if six.PY3:
+        return parameter in inspect.signature(func).parameters
+    else:
+        args, varargs, varkw, defaults = inspect.getargspec(func)
+        return parameter in args

--- a/cactus/utils/internal.py
+++ b/cactus/utils/internal.py
@@ -1,6 +1,7 @@
 #coding:utf-8
 import six
 import inspect
+from .inspect23 import getargspec as six_getargspec
 
 # Adapted from: http://kbyanc.blogspot.com/2007/07/python-more-generic-getargspec.html
 
@@ -33,16 +34,16 @@ def getargspec(obj):
         raise TypeError("%s is not callable" % type(obj))
     try:
         if inspect.isfunction(obj):
-            return inspect.getargspec(obj)
+            return six_getargspec(obj)
         elif hasattr(obj, FUNC_OBJ_ATTR):
             # For methods or classmethods drop the first
             # argument from the returned list because
             # python supplies that automatically for us.
             # Note that this differs from what
-            # inspect.getargspec() returns for methods.
+            # six_getargspec()() returns for methods.
             # NB: We use im_func so we work with
             #     instancemethod objects also.
-            spec = inspect.getargspec(getattr(obj, FUNC_OBJ_ATTR))
+            spec = six_getargspec(getattr(obj, FUNC_OBJ_ATTR))
             return inspect.ArgSpec(spec.args[:1], spec.varargs, spec.keywords, spec.defaults)
         elif inspect.isclass(obj):
             return getargspec(obj.__init__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.6,<1.7
+Django==1.11.29
 django-markwhat>=1.4,<2
 markdown2
 argparse

--- a/run.py
+++ b/run.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
-
+import sys
 import cactus
 
 from cactus.cli import main
 
-print "Using: %s" % cactus.__file__
+print("Using: %s" % cactus.__file__)
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
This PR updates Django to 1.11 (latest version supporting Python2.7) and removes Python3 deprecation warnings (#280).

It maintains Python2.7 compatibility, although it might be a good idea to drop Python2.7 support altogether...